### PR TITLE
Handle missing statements in routes

### DIFF
--- a/routes/statements_routes.py
+++ b/routes/statements_routes.py
@@ -13,6 +13,8 @@ def view():
         return render_template('statements.html', error='Provide ticker or path from fetch step.')
 
     std = standardize_statements(ticker=ticker, folder_path=path, data_dir=current_app.config['DATA_DIR'])
+    if std.error:
+        return render_template('statements.html', error=std.error, ticker=ticker, folder_path=path)
     return render_template('statements.html', result=std, ticker=ticker, folder_path=path)
 
 
@@ -21,5 +23,8 @@ def export():
     ticker = (request.args.get('ticker') or '').upper().strip()
     path = request.args.get('path')
     std = standardize_statements(ticker=ticker, folder_path=path, data_dir=current_app.config['DATA_DIR'])
+    if std.error:
+        return render_template('statements.html', error=std.error, ticker=ticker, folder_path=path)
+
     out_path = export_statements_xlsx(std, ticker=ticker or 'COMPANY', out_dir=current_app.config['DATA_DIR'])
     return send_file(out_path, as_attachment=True)

--- a/services/valuation.py
+++ b/services/valuation.py
@@ -2,7 +2,8 @@ import math
 import os
 import pandas as pd
 import yfinance as yf
-from .statements import standardize_statements
+
+from .statements import StandardizedStatements, standardize_statements
 
 
 def _latest_value(df: pd.DataFrame, item: str):
@@ -15,9 +16,11 @@ def _latest_value(df: pd.DataFrame, item: str):
     return float(series.iloc[0])
 
 
-def simple_dcf(ticker: str, wacc: float, terminal_growth: float, forecast_years: int = 5, data_dir: str = './data'):
-    std = standardize_statements(ticker=ticker, data_dir=data_dir)
-    is_df, cf_df, bs_df = std['income_statement'], std['cash_flow'], std['balance_sheet']
+def simple_dcf(
+    ticker: str, wacc: float, terminal_growth: float, forecast_years: int = 5, data_dir: str = './data'
+):
+    std: StandardizedStatements = standardize_statements(ticker=ticker, data_dir=data_dir).ensure_ok()
+    is_df, cf_df, bs_df = std.income_statement, std.cash_flow, std.balance_sheet
 
     cfo = _latest_value(cf_df, 'CFO')
     capex = _latest_value(cf_df, 'Capex')

--- a/tests/test_no_data_flow.py
+++ b/tests/test_no_data_flow.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app import create_app
+from services.statements import StandardizedStatements, StatementDataUnavailable, standardize_statements
+
+
+@pytest.fixture
+def app_with_tmp_data_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv('DATA_DIR', str(tmp_path))
+    application = create_app()
+    application.config.update(TESTING=True)
+    yield application
+
+
+def test_standardize_returns_error_when_data_missing(tmp_path):
+    std: StandardizedStatements = standardize_statements(ticker='MISSING', data_dir=str(tmp_path))
+    assert not std.ok
+    assert std.error
+    with pytest.raises(StatementDataUnavailable):
+        std.ensure_ok()
+
+
+def test_statements_route_reports_missing_data(app_with_tmp_data_dir):
+    client = app_with_tmp_data_dir.test_client()
+    resp = client.get('/statements/?ticker=MISS')
+    assert resp.status_code == 200
+    assert b'Could not locate statements' in resp.data
+
+
+def test_analysis_route_reports_missing_data(app_with_tmp_data_dir):
+    client = app_with_tmp_data_dir.test_client()
+    resp = client.get('/analysis/?ticker=MISS')
+    assert resp.status_code == 200
+    assert b'Could not locate statements' in resp.data


### PR DESCRIPTION
## Summary
- guard the statements routes to surface standardization errors and avoid exporting incomplete data
- reuse a shared standardized statements object throughout the analysis helpers to enforce error handling
- add a typed wrapper with regression tests that cover the missing-data flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc84d9be748323b7771b65fe78b36f